### PR TITLE
Wordpress in subfolder

### DIFF
--- a/classes/package.archive.php
+++ b/classes/package.archive.php
@@ -171,8 +171,15 @@ class DUP_Archive
 	//Get All Directories then filter
 	private function getDirs() 
 	{
-		
-		$rootPath = DUP_Util::SafePath(rtrim(DUPLICATOR_WPROOTPATH, '//' ));
+		if ( !defined('ROOTPATH') )
+		{
+			$rootPath = DUP_Util::SafePath(rtrim(DUPLICATOR_WPROOTPATH, '//'));
+		} else {
+			// something like this should be in wp-config.php
+  			// if ( !defined('ROOTPATH') )
+  			//	define('ROOTPATH', ABSPATH . '/..');
+			$rootPath = DUP_Util::SafePath(rtrim(ROOTPATH));
+	    }
 		$this->Dirs = array();
 		
 		//If the root directory is a filter then we will only need the root files

--- a/classes/package.archive.php
+++ b/classes/package.archive.php
@@ -176,8 +176,9 @@ class DUP_Archive
 			$rootPath = DUP_Util::SafePath(rtrim(DUPLICATOR_WPROOTPATH, '//'));
 		} else {
 			// something like this should be in wp-config.php
-  			// if ( !defined('ROOTPATH') )
-  			//	define('ROOTPATH', ABSPATH . '/..');
+			//$wp_subfolder = "wp";
+			// if ( !defined('ROOTPATH') )
+  			//	    define('ROOTPATH', str_replace($wp_subfolder, '', dirname(__FILE__)));
 			$rootPath = DUP_Util::SafePath(rtrim(ROOTPATH));
 	    }
 		$this->Dirs = array();

--- a/classes/package.php
+++ b/classes/package.php
@@ -287,7 +287,15 @@ class DUP_Package {
 			$this->NameHash		= "{$this->Name}_{$this->Hash}";;
 			$this->Notes		= esc_html($post['package-notes']);
 			//ARCHIVE
-			$this->Archive->PackDir			= rtrim(DUPLICATOR_WPROOTPATH, '/');
+			if ( !defined('ROOTPATH') )
+			{
+				$this->Archive->PackDir			= rtrim(DUPLICATOR_WPROOTPATH, '/');
+			} else {
+				// something like this should be in wp-config.php
+				// if ( !defined('ROOTPATH') )
+				//	define('ROOTPATH', ABSPATH . '/..');
+				$this->Archive->PackDir			= rtrim(ROOTPATH, '/');
+			}
 			$this->Archive->Format			= 'ZIP';
 			$this->Archive->FilterOn		= isset($post['filter-on'])   ? 1 : 0;
 			$this->Archive->FilterDirs		= esc_html($filter_dirs);

--- a/classes/package.php
+++ b/classes/package.php
@@ -292,8 +292,9 @@ class DUP_Package {
 				$this->Archive->PackDir			= rtrim(DUPLICATOR_WPROOTPATH, '/');
 			} else {
 				// something like this should be in wp-config.php
+				//$wp_subfolder = "wp";
 				// if ( !defined('ROOTPATH') )
-				//	define('ROOTPATH', ABSPATH . '/..');
+				//	    define('ROOTPATH', str_replace($wp_subfolder, '', dirname(__FILE__)));
 				$this->Archive->PackDir			= rtrim(ROOTPATH, '/');
 			}
 			$this->Archive->Format			= 'ZIP';

--- a/installer/build/classes/class.config.php
+++ b/installer/build/classes/class.config.php
@@ -52,14 +52,18 @@ class DUPX_Config {
 		$currpath = DupUtil::add_slash(isset($currdata['path']) ? $currdata['path'] : "");
 		$newpath  = DupUtil::add_slash(isset($newdata['path'])  ? $newdata['path'] : "");
 
-		$tmp_htaccess = <<<HTACCESS
+        //CKL this is just for me, had to change it for WP in subdir
+        $tmp_htaccess = <<<HTACCESS
 # BEGIN WordPress
 <IfModule mod_rewrite.c>
 RewriteEngine On
 RewriteBase {$newpath}
 RewriteRule ^index\.php$ - [L]
-RewriteCond %{REQUEST_FILENAME} !-f
-RewriteCond %{REQUEST_FILENAME} !-d
+RewriteCond %{REQUEST_FILENAME} -f [OR]
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule ^ - [L]
+RewriteRule ^(wp-(admin|includes|snapshots).*) wp/$1 [L]
+RewriteRule ^(.*\.php)$ wp/$1 [L]
 RewriteRule . {$newpath}index.php [L]
 </IfModule>
 # END WordPress

--- a/installer/build/classes/class.config.php
+++ b/installer/build/classes/class.config.php
@@ -62,8 +62,8 @@ RewriteRule ^index\.php$ - [L]
 RewriteCond %{REQUEST_FILENAME} -f [OR]
 RewriteCond %{REQUEST_FILENAME} -d
 RewriteRule ^ - [L]
-RewriteRule ^(wp-(admin|includes|snapshots).*) wp/$1 [L]
-RewriteRule ^(.*\.php)$ wp/$1 [L]
+RewriteRule ^(wp-(admin|includes|snapshots).*) ${wp_subfolder}/$1 [L]
+RewriteRule ^(.*\.php)$ ${wp_subfolder}/$1 [L]
 RewriteRule . {$newpath}index.php [L]
 </IfModule>
 # END WordPress


### PR DESCRIPTION
I've found this to be necessary when I have installed wordpress in a subfolder. I keep my website content in a separate wp-config folder at the root, instead of in Wordpress subfolder. This allows duplicator to capture all of the files, not just those in the wordpress installation.
